### PR TITLE
Remove macOS strategy option

### DIFF
--- a/aw_core/config.py
+++ b/aw_core/config.py
@@ -6,6 +6,5 @@ def load_config_toml(name: str, default=None) -> Dict[str, Dict]:
             "exclude_title": False,
             "exclude_titles": [],
             "poll_time": 1.0,
-            "strategy_macos": "swift",
         }
     }

--- a/aw_watcher_virtualdesktop/config.py
+++ b/aw_watcher_virtualdesktop/config.py
@@ -7,7 +7,6 @@ default_config = """
 exclude_title = false
 exclude_titles = []
 poll_time = 1.0
-strategy_macos = "swift"
 """.strip()
 
 
@@ -21,10 +20,9 @@ def parse_args():
     default_poll_time = config["poll_time"]
     default_exclude_title = config["exclude_title"]
     default_exclude_titles = config["exclude_titles"]
-    default_strategy_macos = config["strategy_macos"]
 
     parser = argparse.ArgumentParser(
-        description="A cross platform window watcher for Activitywatch.\nSupported on: Linux (X11), macOS and Windows."
+        description="A cross platform window watcher for ActivityWatch.\nSupported on: Linux (X11) and Windows."
     )
     parser.add_argument("--host", dest="host")
     parser.add_argument("--port", dest="port")
@@ -46,13 +44,6 @@ def parse_args():
     parser.add_argument("--oneshot", dest="oneshot", action="store_true")
     parser.add_argument(
         "--poll-time", dest="poll_time", type=float, default=default_poll_time
-    )
-    parser.add_argument(
-        "--strategy",
-        dest="strategy",
-        default=default_strategy_macos,
-        choices=["jxa", "applescript", "swift"],
-        help="(macOS only) strategy to use for retrieving the active window",
     )
     parsed_args = parser.parse_args()
     return parsed_args

--- a/aw_watcher_virtualdesktop/main.py
+++ b/aw_watcher_virtualdesktop/main.py
@@ -51,7 +51,7 @@ def main():
         raise Exception("DISPLAY environment variable not set")
 
     if args.oneshot:
-        data = get_current_window(args.strategy)
+        data = get_current_window()
         if data is not None and "virtual_desktop" not in data:
             data["virtual_desktop"] = get_virtual_desktop()
         print(json.dumps(data))
@@ -81,45 +81,21 @@ def main():
     client.wait_for_start()
 
     with client:
-        if sys.platform == "darwin" and args.strategy == "swift":
-            logger.info("Using swift strategy, calling out to swift binary")
-            binpath = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), "aw-watcher-virtualdesktop-macos"
-            )
-
-            try:
-                p = subprocess.Popen(
-                    [
-                        binpath,
-                        client.server_address,
-                        bucket_id,
-                        client.client_hostname,
-                        client.client_name,
-                    ]
-                )
-                # terminate swift process when this process dies
-                signal.signal(signal.SIGTERM, lambda *_: kill_process(p.pid))
-                p.wait()
-            except KeyboardInterrupt:
-                print("KeyboardInterrupt")
-                kill_process(p.pid)
-        else:
-            heartbeat_loop(
-                client,
-                bucket_id,
-                poll_time=args.poll_time,
-                strategy=args.strategy,
-                exclude_title=args.exclude_title,
-                exclude_titles=[
-                    try_compile_title_regex(title)
-                    for title in args.exclude_titles
-                    if title is not None
-                ],
-            )
+        heartbeat_loop(
+            client,
+            bucket_id,
+            poll_time=args.poll_time,
+            exclude_title=args.exclude_title,
+            exclude_titles=[
+                try_compile_title_regex(title)
+                for title in args.exclude_titles
+                if title is not None
+            ],
+        )
 
 
 def heartbeat_loop(
-    client, bucket_id, poll_time, strategy, exclude_title=False, exclude_titles=[]
+    client, bucket_id, poll_time, exclude_title=False, exclude_titles=[]
 ):
     while True:
         if os.getppid() == 1:
@@ -128,7 +104,7 @@ def heartbeat_loop(
 
         current_window = None
         try:
-            current_window = get_current_window(strategy)
+            current_window = get_current_window()
             logger.debug(current_window)
         except (FatalError, OSError):
             # Fatal exceptions should quit the program

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -7,7 +7,7 @@ main_mod = importlib.import_module('aw_watcher_virtualdesktop.main')
 def test_oneshot(monkeypatch, capsys):
     monkeypatch.setattr(sys, 'argv', ['aw-watcher-virtualdesktop', '--oneshot'])
     monkeypatch.setenv('DISPLAY', ':0')
-    monkeypatch.setattr(main_mod, 'get_current_window', lambda strategy=None: {'app': 'a', 'title': 't'})
+    monkeypatch.setattr(main_mod, 'get_current_window', lambda: {'app': 'a', 'title': 't'})
     monkeypatch.setattr(main_mod, 'get_virtual_desktop', lambda: 5)
     main_mod.main()
     out, _ = capsys.readouterr()


### PR DESCRIPTION
## Summary
- drop macOS-specific `--strategy` CLI flag and config entry
- update CLI description for Windows/Linux
- remove strategy handling from `main.py`
- adjust tests for new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851f26d99788325afb06735db3f39b4